### PR TITLE
test: chain: add unit tests to the syncer

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -1244,25 +1244,3 @@ func (syncer *Syncer) CheckBadBlockCache(blk cid.Cid) (string, bool) {
 	bbr, ok := syncer.bad.Has(blk)
 	return bbr.String(), ok
 }
-
-func (syncer *Syncer) getLatestBeaconEntry(ctx context.Context, ts *types.TipSet) (*types.BeaconEntry, error) {
-	cur := ts
-	for i := 0; i < 20; i++ {
-		cbe := cur.Blocks()[0].BeaconEntries
-		if len(cbe) > 0 {
-			return &cbe[len(cbe)-1], nil
-		}
-
-		if cur.Height() == 0 {
-			return nil, xerrors.Errorf("made it back to genesis block without finding beacon entry")
-		}
-
-		next, err := syncer.store.LoadTipSet(ctx, cur.Parents())
-		if err != nil {
-			return nil, xerrors.Errorf("failed to load parents when searching back for latest beacon entry: %w", err)
-		}
-		cur = next
-	}
-
-	return nil, xerrors.Errorf("found NO beacon entries in the 20 latest tipsets")
-}

--- a/chain/sync_manager_test.go
+++ b/chain/sync_manager_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/filecoin-project/lotus/chain/types"
 	"github.com/filecoin-project/lotus/chain/types/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -242,4 +243,37 @@ func TestSyncManager(t *testing.T) {
 		fmt.Println("op3: ", op3.ts.Cids())
 		op3.done()
 	})
+}
+
+// TestSyncManagerBucketSet tests the basic lifecycle of the syncBucketSet.
+func TestSyncManagerBucketSet(t *testing.T) {
+	ts1 := mock.TipSet(mock.MkBlock(nil, 0, 0))
+	ts2 := mock.TipSet(mock.MkBlock(ts1, 1, 0))
+	bucket1 := newSyncTargetBucket(ts1, ts2)
+	bucketSet := syncBucketSet{buckets: []*syncTargetBucket{bucket1}}
+	fmt.Println("bucketSet: ", bucketSet.String())
+
+	// inserting a tipset from an existing chain, should add to an existing bucket
+	ts3 := mock.TipSet(mock.MkBlock(ts2, 2, 0))
+	bucketSet.Insert(ts3)
+	require.Equal(t, 1, len(bucketSet.buckets))
+	require.Equal(t, 3, len(bucketSet.buckets[0].tips))
+	fmt.Println("bucketSet: ", bucketSet.String())
+
+	// inserting a tipset from  new chain, should create a new bucket
+	ts4fork := mock.TipSet(mock.MkBlock(nil, 1, 1))
+	bucketSet.Insert(ts4fork)
+	require.Equal(t, 2, len(bucketSet.buckets))
+	require.Equal(t, 3, len(bucketSet.buckets[0].tips))
+	require.Equal(t, 1, len(bucketSet.buckets[1].tips))
+	fmt.Println("bucketSet: ", bucketSet.String())
+
+	// Pop removes the best bucket, e.g. bucket1
+	popped := bucketSet.Pop()
+	require.Equal(t, popped, bucket1)
+	require.Equal(t, 1, len(bucketSet.buckets))
+
+	// PopRelated removes the bucket containing the given tipset, leaving the set empty
+	bucketSet.PopRelated(ts4fork)
+	require.Equal(t, 0, len(bucketSet.buckets))
 }

--- a/chain/sync_test.go
+++ b/chain/sync_test.go
@@ -438,6 +438,7 @@ func (tu *syncTestUtil) waitUntilSync(from, to int) {
 }
 
 func (tu *syncTestUtil) waitUntilSyncTarget(to int, target *types.TipSet) {
+	fmt.Println("DIVIC: start")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -445,6 +446,7 @@ func (tu *syncTestUtil) waitUntilSyncTarget(to int, target *types.TipSet) {
 	if err != nil {
 		tu.t.Fatal(err)
 	}
+	fmt.Println("DIVIC: after chain notify")
 
 	timeout := time.After(5 * time.Second)
 
@@ -457,6 +459,7 @@ func (tu *syncTestUtil) waitUntilSyncTarget(to int, target *types.TipSet) {
 				}
 			}
 		case <-timeout:
+			fmt.Println("DIVIC: timeout")
 			tu.t.Fatal("waitUntilSyncTarget timeout")
 		}
 	}
@@ -502,6 +505,75 @@ func TestSyncMining(t *testing.T) {
 		tu.waitUntilSync(0, client)
 		tu.compareSourceState(client)
 	}
+}
+
+// TestSyncManualBadTS tests manually marking and unmarking blocks in the bad TS cache
+func TestSyncManualBadTS(t *testing.T) {
+	// Test setup:
+	// - source node is fully synced,
+	// - client node is unsynced
+	// - client manually marked source's head and it's parent as bad
+	H := 50
+	tu := prepSyncTest(t, H)
+
+	client := tu.addClientNode()
+	require.NoError(t, tu.mn.LinkAll())
+
+	sourceHead, err := tu.nds[source].ChainHead(tu.ctx)
+	require.NoError(tu.t, err)
+
+	clientHead, err := tu.nds[client].ChainHead(tu.ctx)
+	require.NoError(tu.t, err)
+
+	require.True(tu.t, !sourceHead.Equals(clientHead), "source and client should be out of sync in test setup")
+
+	err = tu.nds[client].SyncMarkBad(tu.ctx, sourceHead.Cids()[0])
+	require.NoError(tu.t, err)
+
+	sourceHeadParent := sourceHead.Parents().Cids()[0]
+	err = tu.nds[client].SyncMarkBad(tu.ctx, sourceHeadParent)
+	require.NoError(tu.t, err)
+
+	reason, err := tu.nds[client].SyncCheckBad(tu.ctx, sourceHead.Cids()[0])
+	require.NoError(tu.t, err)
+	require.NotEqual(tu.t, "", reason, "block is not bad after manually marking")
+
+	reason, err = tu.nds[client].SyncCheckBad(tu.ctx, sourceHeadParent)
+	require.NoError(tu.t, err)
+	require.NotEqual(tu.t, "", reason, "block is not bad after manually marking")
+
+	// Assertion 1:
+	// - client shouldn't be synced after timeout, because the source TS is marked bad.
+	// - bad block is the first block that should be synced, 1sec should be enough
+	tu.connect(1, 0)
+	timeout := time.After(1 * time.Second)
+	<-timeout
+
+	clientHead, err = tu.nds[client].ChainHead(tu.ctx)
+	require.NoError(tu.t, err)
+	require.True(tu.t, !sourceHead.Equals(clientHead), "source and client should be out of sync if source head is bad")
+
+	// Assertion 2:
+	// - after unmarking blocks as bad and reconnecting, source & client should be in sync
+	err = tu.nds[client].SyncUnmarkBad(tu.ctx, sourceHead.Cids()[0])
+	require.NoError(tu.t, err)
+
+	reason, err = tu.nds[client].SyncCheckBad(tu.ctx, sourceHead.Cids()[0])
+	require.NoError(tu.t, err)
+	require.Equal(tu.t, "", reason, "block is still bad after manually unmarking")
+
+	err = tu.nds[client].SyncUnmarkAllBad(tu.ctx)
+	require.NoError(tu.t, err)
+
+	reason, err = tu.nds[client].SyncCheckBad(tu.ctx, sourceHeadParent)
+	require.NoError(tu.t, err)
+	require.Equal(tu.t, "", reason, "block is still bad after manually unmarking")
+
+	tu.disconnect(1, 0)
+	tu.connect(1, 0)
+
+	tu.waitUntilSync(0, client)
+	tu.compareSourceState(client)
 }
 
 func TestSyncBadTimestamp(t *testing.T) {


### PR DESCRIPTION
## Related Issues
<!-- link all issues that this PR might resolve/fix. If an issue doesn't exist, include a brief motivation for the change being made.-->

## Proposed Changes
- The `Syncer` component (and related components like the `SyncManager`) had some methods that were not covered in unit tests, and were quite easy to test.
- `func (syncer *Syncer) getLatestBeaconEntry` seems to be dead code, linter reports is as unused and I couldn't find any references to it (and it's a private method of the Syncer).
- These proposed changes provide a small, yet visible bump up in the test coverage for these files.

## Additional Info
- ⚠️ Was `func (syncer *Syncer) getLatestBeaconEntry` left there on purpose?

## Checklist

Before you mark the PR ready for review, please make sure that:
- [x] All commits have a clear commit message.
- [x] The PR title is in the form of of `<PR type>: <area>: <change being made>`
    - example: ` fix: mempool: Introduce a cache for valid signatures`
    - `PR type`: _fix_, _feat_, _INTERFACE BREAKING CHANGE_, _CONSENSUS BREAKING_, _build_, _chore_, _ci_, _docs_,_perf_, _refactor_, _revert_, _style_, _test_
    - `area`: _api_, _chain_, _state_, _vm_, _data transfer_, _market_, _mempool_, _message_, _block production_, _multisig_, _networking_, _paychan_, _proving_, _sealing_, _wallet_, _deps_
- [x] This PR has tests for new functionality or change in behaviour
- [x] If new user-facing features are introduced, clear usage guidelines and / or documentation updates should be included in https://lotus.filecoin.io or [Discussion Tutorials.](https://github.com/filecoin-project/lotus/discussions/categories/tutorials)
- [ ] CI is green
